### PR TITLE
Potentially fix failing PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,4 +25,4 @@ jobs:
       - name: GitHub Docker Action
         uses: matootie/github-docker@v3.1.0
         with:
-          accessToken: ${{ secrets.PACKAGE_ACTIONS_TOKEN }}
+          accessToken: ${{ secrets.PACKAGE_ACTIONS_TOKEN || github.token }}


### PR DESCRIPTION
Never saw this somehow.

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

Dependabot PRs will fail with the supplied token that has write permissions. This change allows the built in GitHub token to be supplied in case the other one with write permissions is missing. This _should_ fix the issue, but who knows.