### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <JDA.version>v5.0.0-alpha.13</JDA.version>
         <archunit.version>0.23.1</archunit.version>
-        <assertj-core.version>3.22.0</assertj-core.version>
+        <assertj-core.version>3.23.1</assertj-core.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-text.version>1.9</commons-text.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
         <relativePath/>
     </parent>
     <groupId>dev.nincodedo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <sap-conversational-ai-java-api.version>0.0.4</sap-conversational-ai-java-api.version>
-        <pitest-maven.version>1.8.0</pitest-maven.version>
+        <pitest-maven.version>1.9.0</pitest-maven.version>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sortpom-maven-plugin.version>3.1.3</sortpom-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
                     <dependency>
                         <groupId>org.pitest</groupId>
                         <artifactId>pitest-junit5-plugin</artifactId>
-                        <version>0.15</version>
+                        <version>1.0.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <pitest-maven.version>1.8.0</pitest-maven.version>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <sortpom-maven-plugin.version>3.1.0</sortpom-maven-plugin.version>
+        <sortpom-maven-plugin.version>3.1.3</sortpom-maven-plugin.version>
         <syllable-counter.version>4.1.0</syllable-counter.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <maven.compiler.source>18</maven.compiler.source>


### PR DESCRIPTION
Bump sortpom-maven-plugin from 3.1.0 to 3.1.3

Bumps [sortpom-maven-plugin](https://github.com/Ekryd/sortpom) from 3.1.0 to 3.1.3.
- [Release notes](https://github.com/Ekryd/sortpom/releases)
- [Commits](https://github.com/Ekryd/sortpom/compare/sortpom-parent-3.1.0...sortpom-parent-3.1.3)

---
updated-dependencies:
- dependency-name: com.github.ekryd.sortpom:sortpom-maven-plugin
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Bump assertj-core from 3.22.0 to 3.23.1

Bumps [assertj-core](https://github.com/assertj/assertj-core) from 3.22.0 to 3.23.1.
- [Release notes](https://github.com/assertj/assertj-core/releases)
- [Commits](https://github.com/assertj/assertj-core/compare/assertj-core-3.22.0...assertj-core-3.23.1)

---
updated-dependencies:
- dependency-name: org.assertj:assertj-core
  dependency-type: direct:development
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Bump pitest-junit5-plugin from 0.15 to 1.0.0

Bumps [pitest-junit5-plugin](https://github.com/pitest/pitest-junit5-plugin) from 0.15 to 1.0.0.
- [Release notes](https://github.com/pitest/pitest-junit5-plugin/releases)
- [Commits](https://github.com/pitest/pitest-junit5-plugin/compare/0.15...1.0.0)

---
updated-dependencies:
- dependency-name: org.pitest:pitest-junit5-plugin
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

Bump pitest-maven from 1.8.0 to 1.9.0

Bumps [pitest-maven](https://github.com/hcoles/pitest) from 1.8.0 to 1.9.0.
- [Release notes](https://github.com/hcoles/pitest/releases)
- [Commits](https://github.com/hcoles/pitest/compare/1.8.0...1.9.0)

---
updated-dependencies:
- dependency-name: org.pitest:pitest-maven
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Bump spring-boot-starter-parent from 2.7.0 to 2.7.1

Bumps [spring-boot-starter-parent](https://github.com/spring-projects/spring-boot) from 2.7.0 to 2.7.1.
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.7.0...v2.7.1)

---
updated-dependencies:
- dependency-name: org.springframework.boot:spring-boot-starter-parent
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>