### PR TITLE
Bump google-github-actions/get-gke-credentials from 0.7.0 to 0.8.0, Bump sortpom-maven-plugin from 3.1.3 to 3.2.0, Bump pitest-maven from 1.9.2 to 1.9.3

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: GKE Login
-        uses: google-github-actions/get-gke-credentials@v0.7.0
+        uses: google-github-actions/get-gke-credentials@v0.8.0
         with:
           cluster_name: ninbot-cluster
           location: us-central1-c

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <sap-conversational-ai-java-api.version>0.0.4</sap-conversational-ai-java-api.version>
-        <pitest-maven.version>1.9.2</pitest-maven.version>
+        <pitest-maven.version>1.9.3</pitest-maven.version>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sortpom-maven-plugin.version>3.2.0</sortpom-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <pitest-maven.version>1.9.2</pitest-maven.version>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <sortpom-maven-plugin.version>3.1.3</sortpom-maven-plugin.version>
+        <sortpom-maven-plugin.version>3.2.0</sortpom-maven-plugin.version>
         <syllable-counter.version>4.1.0</syllable-counter.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <maven.compiler.source>18</maven.compiler.source>


### PR DESCRIPTION
Bump google-github-actions/get-gke-credentials from 0.7.0 to 0.8.0

Bumps [google-github-actions/get-gke-credentials](https://github.com/google-github-actions/get-gke-credentials) from 0.7.0 to 0.8.0.
- [Release notes](https://github.com/google-github-actions/get-gke-credentials/releases)
- [Changelog](https://github.com/google-github-actions/get-gke-credentials/blob/main/CHANGELOG.md)
- [Commits](https://github.com/google-github-actions/get-gke-credentials/compare/v0.7.0...v0.8.0)

---
updated-dependencies:
- dependency-name: google-github-actions/get-gke-credentials
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Bump sortpom-maven-plugin from 3.1.3 to 3.2.0

Bumps [sortpom-maven-plugin](https://github.com/Ekryd/sortpom) from 3.1.3 to 3.2.0.
- [Release notes](https://github.com/Ekryd/sortpom/releases)
- [Commits](https://github.com/Ekryd/sortpom/compare/sortpom-parent-3.1.3...sortpom-parent-3.2.0)

---
updated-dependencies:
- dependency-name: com.github.ekryd.sortpom:sortpom-maven-plugin
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Bump pitest-maven from 1.9.2 to 1.9.3

Bumps [pitest-maven](https://github.com/hcoles/pitest) from 1.9.2 to 1.9.3.
- [Release notes](https://github.com/hcoles/pitest/releases)
- [Commits](https://github.com/hcoles/pitest/compare/1.9.2...1.9.3)

---
updated-dependencies:
- dependency-name: org.pitest:pitest-maven
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>